### PR TITLE
Fix inference-only installation dependencies and pin flash-attn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,23 @@ Install required packages:
 
 **[Inference-only]**
 
-```bash
-pip install torch==2.4.0 torchvision==0.17.0 --extra-index-url https://download.pytorch.org/whl/cu118
+For stable inference, install the following package versions:
 
-pip install flash-attn --no-build-isolation
+```bash
+# PyTorch and torchvision for CUDA 11.8
+pip install torch==2.4.0 torchvision==0.19.0 --extra-index-url https://download.pytorch.org/whl/cu118
+
+# Flash-attn pinned to a compatible version
+pip install flash-attn==2.7.3 --no-build-isolation --upgrade
+
+# Transformers and accelerate
 pip install transformers==4.46.3 accelerate==1.0.1
+
+# Video processing dependencies
 pip install decord ffmpeg-python imageio opencv-python
 ```
+> ⚠ **Note:** For CUDA 11.8 with `torch==2.4.0` and `torchvision==0.19.0`, use `flash-attn==2.7.3`.  
+> If you are using a different Python or CUDA version, please check the [flash-attn releases](https://github.com/Dao-AILab/flash-attention/releases/) to select the compatible wheel. Using incompatible versions may break the setup.
 
 **[Training]**
 


### PR DESCRIPTION
### Issue:
The inference setup encountered dependency conflicts:
- Installing `torch==2.4.0` with `torchvision==0.17.0` caused a version conflict error.
- The latest `flash-attn` versions (>=2.8) do not compile correctly with CUDA 11.8 and Python 3.10/3.11, causing setup failures.

### Solution:
- Updated the inference installation to use:
  - `torch==2.4.0`
  - `torchvision==0.19.0`
  - `flash-attn==2.7.3` (pinned for compatibility with CUDA 11.8, torch 2.4.0, torchvision 0.17.0 and Python 3.10/3.11)
  - `transformers==4.46.3`
  - `accelerate==1.0.1`
  - `decord`, `ffmpeg-python`, `imageio`, `opencv-python`
- Added a note clarifying the required combination of CUDA, torch, torchvision, and flash-attn versions.
- Provided a link to the [flash-attn releases](https://github.com/Dao-AILab/flash-attention/releases/) for alternative setups.

### Outcome:
This ensures a stable and reproducible inference setup and prevents installation failures due to incompatible package versions.